### PR TITLE
Fixed adding empty directories recursively

### DIFF
--- a/module/Client/src/Client/Service/ZpkInvokable.php
+++ b/module/Client/src/Client/Service/ZpkInvokable.php
@@ -302,37 +302,37 @@ class ZpkInvokable
      */
     protected function addDir($zpk, $directory, $baseDir = null)
     {
-        $dir = dir($directory);
-        if($dir) {
-            if($baseDir) {
-                $currentZipFolder = $baseDir.'/'.basename($directory);
-            } else {
-                $currentZipFolder = basename($directory);
-            }
-
-            while($path = $dir->read()) {
-                if(in_array($path, array('.','..'))) {
-                    continue;
-                }
-
-                $path = $directory."/".$path;
-                if(is_dir($path)) {
-                    $countFiles = scandir($path);
-                    if(count($countFiles) <= 2) {
-                        $zpk->addEmptyDir($this->fixZipPath($currentZipFolder.'/'.basename($path)));
-                    } else {
+        if($baseDir) {
+            $currentZipFolder = $baseDir.'/'.basename($directory);
+        } else {
+            $currentZipFolder = basename($directory);
+        }
+        
+        $countFiles = scandir($directory);
+        if(count($countFiles) <= 2) {
+            $zpk->addEmptyDir($currentZipFolder);
+        } else {
+            $dir = dir($directory);
+            if($dir) {
+                while($path = $dir->read()) {
+                    if(in_array($path, array('.','..'))) {
+                        continue;
+                    }
+    
+                    $path = $directory."/".$path;
+                    if(is_dir($path)) {
                         $this->addDir($zpk, $path, $currentZipFolder);
+                    } else if(file_exists($path)){
+                        $success = $zpk->addFile($path, $this->fixZipPath($currentZipFolder.'/'.basename($path)));
+                        if(!$success) {
+                            throw new \Zend\ServiceManager\Exception\RuntimeException("Path '$path' cannot be added zpk");
+                        }
+                    } else {
+                        throw new \Zend\ServiceManager\Exception\RuntimeException("Path '$path' is not existing. Verify your deployment.properties!");
                     }
-                } else if(file_exists($path)){
-                    $success = $zpk->addFile($path, $this->fixZipPath($currentZipFolder.'/'.basename($path)));
-                    if(!$success) {
-                        throw new \Zend\ServiceManager\Exception\RuntimeException("Path '$path' cannot be added zpk");
-                    }
-                } else {
-                    throw new \Zend\ServiceManager\Exception\RuntimeException("Path '$path' is not existing. Verify your deployment.properties!");
                 }
+                $dir->close();
             }
-            $dir->close();
         }
     }
 
@@ -458,4 +458,3 @@ class ZpkInvokable
 
     }
 }
-


### PR DESCRIPTION
Last time I thought I fixed it but it was only adding top level empty directories. In this fix I moved adding empty directories to recursive addDir method so it's able to also add empty subdirectories
