### PR TITLE
Updated $allowedExtensions array

### DIFF
--- a/bin/create-phar.php
+++ b/bin/create-phar.php
@@ -73,7 +73,7 @@ function addDir($phar, $sDir, $baseDir = null)
     );
 
     $allowedExtensions = array (
-        'php','phtml','xsd'
+        'php','phtml','xsd','xml','properties'
     );
 
     foreach ($oDir as $sFile) {


### PR DESCRIPTION
The previous array excluded the deployment.properties and deployment.xml files from being included in the phar when built, which resulted in the following error when running the initZpk (or createZpk) command from the command line:
# 
#    The application has thrown an exception!

 ErrorException
 copy(phar:///Users/pleckey/Development/Projects/laravel-starter/zs-client.phar/module/Client/src/Client/Service/../../../config/zpk/deployment.properties): failed to open stream: phar error: "module/Client/config/zpk/deployment.properties" is not a file in phar "/Users/pleckey/Development/Projects/laravel-starter/zs-client.phar"
