### PR TITLE
Handling the case where the scriptsdir is defined in deployment.xml

### DIFF
--- a/module/Client/src/Client/Service/ZpkInvokable.php
+++ b/module/Client/src/Client/Service/ZpkInvokable.php
@@ -278,6 +278,9 @@ class ZpkInvokable
 
                     $zpk->addFile($fullPath, $this->fixZipPath($baseDir.$path));
                 } else if(is_dir($fullPath)) {
+               	 	if($key=='scriptsdir.includes' && isset($xml->scriptsdir) && empty($path)) {
+                	     $baseDir = null;           		
+                	}
                     $this->addDir($zpk, $fullPath, $baseDir);
                 } else {
                     throw new \Zend\ServiceManager\Exception\RuntimeException("Path '$fullPath' is not existing. Verify your deployment.properties!");


### PR DESCRIPTION
When the &lt;scriptsdir&gt; element was defined, it was creating the incorrect
path within the .zpk file.

---- Previous Example 1 ----
deployment.xml:
&lt;scriptsdir&gt;zenddeploymentscripts&lt;/scriptsdir&gt;

deployment.properties:
scriptsdir.includes = zenddeploymentscripts/post_stage.php

application.zpk path result:
zenddeploymentscripts/zenddeploymentscripts/post_stage.php

---- Previous Example 2 ----
deployment.xml:
&lt;scriptsdir&gt;zenddeploymentscripts&lt;/scriptsdir&gt;

deployment.properties:
scriptsdir.includes = post_stage.php

application.zpk path result:
Errors, saying post_stage.php does not exist

---- After This Commit ----
deployment.xml:
&lt;scriptsdir&gt;zenddeploymentscripts&lt;/scriptsdir&gt;

deployment.properties:
scriptsdir.includes = post_stage.php

application.zpk path result:
zenddeploymentscripts/post_stage.php
