### PR TITLE
Supporting using zenddevops/client as a vendor.

### DIFF
--- a/bin/zs-client.php
+++ b/bin/zs-client.php
@@ -11,6 +11,8 @@ error_reporting(E_ALL);
 ini_set("display_errors", 1);
 ini_set('user_agent', 'Zend Server WebAPI Client');
 
+set_include_path(get_include_path(). PATH_SEPARATOR . getcwd());
+
 $basePath = dirname(__DIR__);
 if(!defined('PHAR')) {
     define('CWD',getcwd());


### PR DESCRIPTION
When installing zenddevops/client as a vendor into another project, it
adds the zs-client.php inside of vendor/bin.  When you try to run the
command...

php vendor/bin/zs-client.php installApp --zpk="/tmp/app-1.0.0.zpk"

...it could not find vendor/autoload.php.

This commit adds the cwd to the include path before it is changed inside
of zs-client.php.
