### PR TITLE
Give vhost related commands option to read template from file

### DIFF
--- a/module/Client/src/Client/Controller/ApiController.php
+++ b/module/Client/src/Client/Controller/ApiController.php
@@ -13,6 +13,40 @@ class ApiController extends DefaultApiController
 {
     protected $apiManager;
 
+    public function vhostAddSecureAction($args)
+    {
+        return $this->handleVhostAction($args);
+    }
+
+    public function vhostValidateTemplate($args)
+    {
+        return $this->handleVhostAction($args);
+    }
+
+    public function vhostEditAction($args)
+    {
+        return $this->handleVhostAction($args);
+    }
+
+    public function vhostAddSecureIbmi($args)
+    {
+        return $this->handleVhostAction($args);
+    }
+
+    public function vhostAddAction($args)
+    {
+        return $this->handleVhostAction($args);
+    }
+
+    private function handleVhostAction($args)
+    {
+        if (isset($args['template']) && is_file($args['template'])) {
+            $args['template'] = file_get_contents($args['template']);
+        }
+
+        return $this->sendApiRequest($args);
+    }
+
     /**
      * User-friendly verions of the applicationDeploy command.
      *


### PR DESCRIPTION
We dynamically create vhosts via zs-client in an ant task. Passing the vhost template escaped as a commandline argument was just not possible. 

I built in a check that if the `--template` parameter resolves to a file path, then the content of the file i read in php. Usage:  `zs-client ... --template=/path/to/vhost.config`

This change should be BC. 

Do I have to re-generate the phar and add it to this pull request? 
