### PR TITLE
Adding directories to scriptsdir.includes

### DIFF
--- a/module/Client/src/Client/Service/ZpkInvokable.php
+++ b/module/Client/src/Client/Service/ZpkInvokable.php
@@ -333,7 +333,9 @@ class ZpkInvokable
                     if (in_array($baseDir . '/' . $path, $excludes)) continue;
                     $zpk->addFile($fullPath, $this->fixZipPath($baseDir . '/' . $path));
                 } elseif (is_dir($fullPath)) {
-                    $this->addDir($zpk, $fullPath, $baseDir, $excludes);
+                    // Scripts directories should be added differently
+                    $isScriptDirectory = ($key=='scriptsdir.includes');
+                    $this->addDir($zpk, $fullPath, $baseDir, $excludes, $isScriptDirectory);
                 } else {
                     throw new \Zend\ServiceManager\Exception\RuntimeException("Path '$fullPath' is not existing. Verify your deployment.properties!");
                 }
@@ -364,9 +366,11 @@ class ZpkInvokable
      * @param string     $directory
      * @param string     $baseDir
      */
-    protected function addDir($zpk, $directory, $baseDir = null, $excludes = array())
-    {
-        if ($baseDir) {
+    protected function addDir($zpk, $directory, $baseDir = null, $excludes = array(), $isSciptDirectory = false)
+    {   
+        if ($isSciptDirectory AND $baseDir) {
+            $currentZipFolder = $baseDir;
+        } elseif ($baseDir) {
             $currentZipFolder = $baseDir.'/'.basename($directory);
         } else {
             $currentZipFolder = basename($directory);
@@ -387,7 +391,7 @@ class ZpkInvokable
 
                     $path = $directory."/".$path;
                     if (is_dir($path)) {
-                        $this->addDir($zpk, $path, $currentZipFolder, $excludes);
+                        $this->addDir($zpk, $path, $currentZipFolder, $excludes, $isSciptDirectory);
                     } elseif (file_exists($path)) {
                         $success = $zpk->addFile($path, $this->fixZipPath($currentZipFolder.'/'.basename($path)));
                         if (!$success) {


### PR DESCRIPTION
Scripts directory within the ZPK was not being generated correctly (when directories are added to scriptsdir.includes) for two reasons:

1) The files were contained within a double sub directory : /scripts/scripts
2) Sub-directories of the scripts folder were not being flattened, as is the case when packaging using Zend Studio

Packaging through Zend Studio allows directories to be included in scriptsdir.includes, the behaviour you see there is it copies all the files within that directory, along with all files in any sub-directories, into the scriptsdir defined in the XML - giving you a single directory in the package (named after scriptsdir) which contains all the files, flattened out with no sub-directories.

My update should match this behaviour, but I didnt check adding single files to the scriptsdir.includes as this looked to be handled fine already in the pack() method.