### PR TITLE
Fixed wrappers for create-phar.php

### DIFF
--- a/bin/build-phar.bat
+++ b/bin/build-phar.bat
@@ -1,2 +1,2 @@
 del zs-client.phar
-php create-phar.php
+php -d phar.readonly=0 create-phar.php

--- a/bin/build-phar.sh
+++ b/bin/build-phar.sh
@@ -27,7 +27,7 @@ wget http://getcomposer.org/composer.phar
 php composer.phar install --no-dev
 # Update the library to the latest git version from master
 (cd vendor/zenddevops/webapi/; git pull origin master)
-php bin/create-phar.php 
+php -d phar.readonly=0 bin/create-phar.php 
 
 read -p "Do you want to commit-n-push the newly compiled phar file (Y/n)?" RESULT
 if [ "$RESULT" != "n" ]; then


### PR DESCRIPTION
Added PHP phar.readonly=0 directive to PHP execution, Error extract: "creating archive zs-client.phar disabled by the php.ini setting phar.readonly"