### PR TITLE
Relaxing version constraint for Zend Framework. #81

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	],
 	"require" : {
 		"php" : ">=5.3.3",
-		"zendframework/zend-i18n" : "~2.4.0",
+		"zendframework/zend-i18n" : "~2.4",
 		"openlss/lib-array2xml" : "dev-master",
 		"zenddevops/webapi" : "dev-master",
 		"mustangostang/spyc" : "dev-master",
@@ -31,7 +31,7 @@
 	"require-dev" : {
 		"phpunit/phpunit" : "4.1.*",
 		"fabpot/php-cs-fixer": "1.10.*",
-		"zendframework/zendframework" : "~2.4.0",
+		"zendframework/zendframework" : "~2.4",
 		"satooshi/php-coveralls": "dev-master",
 		"phpunit/phpcov": "2.0.*"
 	},


### PR DESCRIPTION
Relaxing the version constraint to allow ZendServerSDK to be used inside a project using ZF 2.5+.

For more information discussing this issue please see "Dependency restriction to ZF 2.4.x https://github.com/zend-patterns/ZendServerSDK/issues/81"