### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
+matrix:
+  include:
+  - php: 5.3
+    dist: precise
 
 install:
   - composer install --prefer-source


### PR DESCRIPTION
Build is broken. PHP 5.3 is supported only on Precise.